### PR TITLE
Minor helptext tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ optional arguments:
   --mask_path MASK_PATH
                         Path to harmonization mask. Harmonization will only be applied to voxels with intensity value == 1.
   --site_colname SITE_COLNAME
-                        colname of the site variable in the dataframe at df_path
+                        name of the site variable column in the table at df_path
   -o OUTPUT_DIR, --output_dir OUTPUT_DIR
                         Root directory of the harmonized images. A subdirectory for each harmonization technique is created. Each of these subdirectories contains the harmonized images for that
                         technique, named exactly the same as in input_dir
   --harmonization_methods {GlobalScaling,Combat} [{GlobalScaling,Combat} ...]
                         Root directory of the harmonized images. A subdirectory for each harmonization technique is created. Each of these subdirectories contains the harmonized images for that
                         technique, named exactly the same as in input_dir
-  --df_path DF_PATH     Path to the dataframe matching each image filename to the corresponding site id. Also contains information on any other variables / covariates to include in the harmonization
+  --df_path DF_PATH     Path to the table matching each image filename to the corresponding site id. Also contains information on any other variables / covariates to include in the harmonization
                         technique
   --covariate_cols COVARIATE_COLS [COVARIATE_COLS ...]
                         Other colnames of covariates to include. Note that columns with numerical values will be treated as continuous and columns with strings will be treated as categorical
@@ -57,17 +57,17 @@ optional arguments:
   --mask_path MASK_PATH
                         Path to harmonization mask. Harmonization will only be applied to voxels with intensity value == 1.
   --site_colname SITE_COLNAME
-                        colname of the site variable in the dataframe at df_path
+                        name of the site variable column in the table at df_path
   -o OUTPUT_DIR, --output_dir OUTPUT_DIR
                         Root directory of the report files.
   --im_path_to_site_id_df_path IM_PATH_TO_SITE_ID_DF_PATH
-                        Path to the dataframe matching each image filenameto the corresponding site id
+                        Path to the table matching each image filenameto the corresponding site id
   --anova_alpha ANOVA_ALPHA
                         Significance level for the anova to be done at each voxel
   --t_test_alpha T_TEST_ALPHA
                         Significance level for the t-tests to be done at each voxel
   --mtc                 Conduct Bonferroni multiple testing correction for the anovas and t-tests
-  --save_dfs            Save the anova and t-test dataframes as part of the report Note that these can get large in file size
+  --save_dfs            Save the anova and t-test tables as part of the report Note that these can get large in file size
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ optional arguments:
   --harmonization_methods {GlobalScaling,Combat} [{GlobalScaling,Combat} ...]
                         Root directory of the harmonized images. A subdirectory for each harmonization technique is created. Each of these subdirectories contains the harmonized images for that
                         technique, named exactly the same as in input_dir
-  --df_path DF_PATH     Path to the table matching each image filename to the corresponding site id. Also contains information on any other variables / covariates to include in the harmonization
+  --df_path DF_PATH     Path to the table matching each image filepath to the corresponding site id. Also contains information on any other variables / covariates to include in the harmonization
                         technique
   --covariate_cols COVARIATE_COLS [COVARIATE_COLS ...]
                         Other colnames of covariates to include. Note that columns with numerical values will be treated as continuous and columns with strings will be treated as categorical
@@ -61,7 +61,7 @@ optional arguments:
   -o OUTPUT_DIR, --output_dir OUTPUT_DIR
                         Root directory of the report files.
   --im_path_to_site_id_df_path IM_PATH_TO_SITE_ID_DF_PATH
-                        Path to the table matching each image filename to the corresponding site id
+                        Path to the table matching each image filepath to the corresponding site id
   --anova_alpha ANOVA_ALPHA
                         Significance level for the anova to be done at each voxel
   --t_test_alpha T_TEST_ALPHA

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ optional arguments:
   -o OUTPUT_DIR, --output_dir OUTPUT_DIR
                         Root directory of the report files.
   --im_path_to_site_id_df_path IM_PATH_TO_SITE_ID_DF_PATH
-                        Path to the table matching each image filenameto the corresponding site id
+                        Path to the table matching each image filename to the corresponding site id
   --anova_alpha ANOVA_ALPHA
                         Significance level for the anova to be done at each voxel
   --t_test_alpha T_TEST_ALPHA

--- a/src/habet/main.py
+++ b/src/habet/main.py
@@ -83,7 +83,7 @@ def _construct_parser():
 
     sub_parser_harmonize.add_argument(
         "--df_path",
-        help="Path to the table matching each image filename "
+        help="Path to the table matching each image file path "
         "to the corresponding site id. Also contains information on any other "
         "variables / covariates to include in the harmonization technique",
         type=Path,
@@ -115,7 +115,7 @@ def _construct_parser():
 
     sub_parser_report.add_argument(
         "--im_path_to_site_id_df_path",
-        help="Path to the table matching each image filename "
+        help="Path to the table matching each image file path "
         "to the corresponding site id",
         type=Path,
         required=True,

--- a/src/habet/main.py
+++ b/src/habet/main.py
@@ -46,7 +46,7 @@ def _construct_parser():
     parent_parser_site_colname = argparse.ArgumentParser(add_help=False)
     parent_parser_site_colname.add_argument(
         "--site_colname",
-        help="colname of the site variable in the dataframe at df_path",
+        help="name of the site variable column in the table at df_path",
         type=str,
         required=True
     )
@@ -83,7 +83,7 @@ def _construct_parser():
 
     sub_parser_harmonize.add_argument(
         "--df_path",
-        help="Path to the dataframe matching each image filename "
+        help="Path to the table matching each image filename "
         "to the corresponding site id. Also contains information on any other "
         "variables / covariates to include in the harmonization technique",
         type=Path,
@@ -115,7 +115,7 @@ def _construct_parser():
 
     sub_parser_report.add_argument(
         "--im_path_to_site_id_df_path",
-        help="Path to the dataframe matching each image filename"
+        help="Path to the table matching each image filename"
         "to the corresponding site id",
         type=Path,
         required=True,
@@ -143,7 +143,7 @@ def _construct_parser():
 
     sub_parser_report.add_argument(
         "--save_dfs",
-        help="Save the anova and t-test dataframes as part of the report "
+        help="Save the anova and t-test tables as part of the report "
         "Note that these can get large in file size",
         action="store_true",
     )

--- a/src/habet/main.py
+++ b/src/habet/main.py
@@ -38,7 +38,7 @@ def _construct_parser():
     parent_parser_mask_path = argparse.ArgumentParser(add_help=False)
     parent_parser_mask_path.add_argument(
         "--mask_path",
-        help="Path to harmonization mask. Harmonization will only be applied"
+        help="Path to harmonization mask. Harmonization will only be applied "
         "to voxels with intensity value == 1.",
         type=Path,
     )
@@ -115,7 +115,7 @@ def _construct_parser():
 
     sub_parser_report.add_argument(
         "--im_path_to_site_id_df_path",
-        help="Path to the table matching each image filename"
+        help="Path to the table matching each image filename "
         "to the corresponding site id",
         type=Path,
         required=True,


### PR DESCRIPTION
# replace 'dataframe' by 'table' in help text

this is because 'dataframe' is pandas specific terminology
and the user does not need to know that pandas is being used in
the background. the user is just providing a csv table and
getting a csv table back as output.

# replace 'filename' by 'file path' in help text

when I was using habet this confused me, because 'filename'
sounds like it just refers to the base name. 'file path' is less
ambiguous about wanting the full paths.